### PR TITLE
Remove unnecessary "background" permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
   "version": "0.2.0",
   "description": "Drop-in encryption for your favorite social network.",
   "permissions": [
-    "background",
     "storage",
     "tabs",
     "*://twitter.com/"


### PR DESCRIPTION
Was causing script to run in background when the Chrome window was closed and creating an unnecessary icon in the system tray.